### PR TITLE
Remove eventual ValueError exception swallowing when async=False

### DIFF
--- a/mamba/enterprise/database.py
+++ b/mamba/enterprise/database.py
@@ -419,9 +419,9 @@ def transact(method):
         kwargs['async'] = kwargs.pop(
             'async', getattr(self, '__mamba_async__', True))
         kwargs['auto_commit'] = kwargs.pop('auto_commit', True)
-        try:
+        if "transactor" in dir(self):
             return self.transactor.run(method, self, *args, **kwargs)
-        except AttributeError:
+        else:
             return self.database.transactor.run(method, self, *args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
Remove eventual exception swallowing when passing the async=False parameter and the decorated function raises ValueError
